### PR TITLE
#10 質問管理画面（ADMIN-001）の実装

### DIFF
--- a/backend/app/routers/questions.py
+++ b/backend/app/routers/questions.py
@@ -26,7 +26,7 @@ async def get_questions(
     return questions
 
 # GET /api/admin/questions 質問一覧取得（全件）
-@router.get("/api/admin/questions", response_model=List[QuestionResponse])
+@router.get("/admin/questions", response_model=List[QuestionResponse])
 async def get_questions(
     request: Request,
     db: Session = Depends(get_db),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "axios": "^1.13.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -308,6 +312,73 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3376,6 +3447,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "axios": "^1.13.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from './components/Layout';
 import Login from './pages/Login';
 import AnswerInput from './pages/AnswerInput';
 import AnswerHistory from './pages/AnswerHistory';
+import QuestionManage from './pages/QuestionManage';
 import SummaryDashboard from './pages/SummaryDashboard';
 
 const AppRoutes = () => {
@@ -46,10 +47,7 @@ const AppRoutes = () => {
         element={
           <ProtectedRoute allowedRoles={['admin']}>
             <Layout>
-              <div className="card-base dashboard-container">
-                <h2>質問管理画面 (管理者ダミー)</h2>
-                <p>バックエンドから取得した実際のロールに基づき、ここにアクセスしています。</p>
-              </div>
+              <QuestionManage />
             </Layout>
           </ProtectedRoute>
         }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -562,13 +562,28 @@ body {
 }
 
 .table-header-cell {
+  min-width: 100px;
+  padding: 16px;
+  font-weight: 600;
+}
+
+.table-header-cell.drag-handle {
+  min-width: 4px;
+}
+
+.table-header-cell.is_public {
+  width: 20px;
+}
+
+.table-header-cell.actions {
+  min-width: 270px;
   padding: 16px;
   font-weight: 600;
 }
 
 .table-body-row {
   border-bottom: 1px solid #f3f4f6;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, transform 0.1s ease-out;
 }
 
 .table-body-row:hover {
@@ -602,4 +617,230 @@ body {
 
 .text-muted {
   color: var(--text-muted);
+}
+
+/* QuestionManage Styles */
+.delete-button {
+  padding: 6px 12px;
+  background-color: #fef2f2;
+  color: #ef4444;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  transition: all 0.2s;
+}
+
+.delete-button:hover {
+  background-color: #fecaca;
+  border-color: #fecaca;
+}
+
+.toggle-publish-button {
+  min-width: 110px;
+  padding: 6px 12px;
+  background-color: #ffffff;
+  color: #4b5563;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  transition: all 0.2s;
+}
+
+.toggle-publish-button:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.add-button {
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  padding: 14px 28px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 4px 6px -1px rgba(79, 70, 229, 0.2);
+}
+
+.add-button:hover {
+  background-color: var(--primary-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 15px -3px rgba(79, 70, 229, 0.3);
+}
+
+.modal-container {
+  border: none;
+  border-radius: 12px;
+  padding: 0;
+  max-width: 450px;
+  width: 90%;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.modal-container::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.modal-content {
+  padding: 24px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.modal-actions button {
+  padding: 10px 20px;
+  min-width: 100px;
+}
+
+.table-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #374151;
+}
+
+.form-select,
+input[type="text"] {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  background-color: #fff;
+  transition: border-color 0.2s;
+}
+
+.form-select:focus,
+input[type="text"]:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+}
+
+.modal-save-button {
+  padding: 6px 12px;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  transition: all 0.2s;
+}
+
+.modal-save-button:hover {
+  background-color: var(--primary-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 15px -3px rgba(79, 70, 229, 0.3);
+}
+
+.modal-cancel-button {
+  padding: 6px 12px;
+  background-color: #ffffff;
+  color: #4b5563;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  transition: all 0.2s;
+}
+
+.modal-cancel-button:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.draggable-row {
+  cursor: default;
+}
+
+.draggable-row:active {
+  cursor: grabbing;
+}
+
+.drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.category-tag {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.category-tag.satisfaction {
+  background-color: #e0e7ff;
+  color: #4338ca;
+}
+
+.category-tag.relationship {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.category-tag.health {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-badge.public {
+  background-color: #ecfdf5;
+  color: #059669;
+}
+
+.status-badge.private {
+  background-color: #f3f4f6;
+  color: #6b7280;
+}
+
+.draggable-row[draggable="true"] {
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.draggable-row.dragging {
+  opacity: 0.5;
+  background-color: #f3f4f6;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -575,6 +575,10 @@ body {
   width: 20px;
 }
 
+.table-header-cell.sort_order {
+  width: 10px;
+}
+
 .table-header-cell.actions {
   min-width: 270px;
   padding: 16px;

--- a/frontend/src/pages/QuestionManage.tsx
+++ b/frontend/src/pages/QuestionManage.tsx
@@ -1,0 +1,344 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { restrictToVerticalAxis, restrictToWindowEdges, restrictToParentElement } from '@dnd-kit/modifiers';
+
+import {
+  getAdminQuestions,
+  createQuestion,
+  updateQuestion,
+  deleteQuestion,
+  patchPublishQuestion,
+  reorderQuestions,
+  Question,
+  QuestionCreate
+} from '../services/api';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  satisfaction: "満足度",
+  relationship: "人間関係",
+  health: "健康状態",
+};
+
+interface SortableRowProps {
+  question: Question;
+  onEdit: (q: Question) => void;
+  onTogglePublish: (id: number, status: boolean) => void;
+  onDelete: (id: number) => void;
+}
+
+const SortableRow: React.FC<SortableRowProps> = ({ question, onEdit, onTogglePublish, onDelete }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: question.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1000 : 'auto',
+    position: 'relative' as const,
+    opacity: isDragging ? 0.5 : 1,
+    backgroundColor: isDragging ? '#f9fafb' : 'transparent',
+    boxShadow: isDragging ? '0 5px 15px rgba(0,0,0,0.1)' : 'none',
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className={`table-body-row ${isDragging ? 'dragging' : ''}`}
+    >
+      <td className="table-body-cell drag-handle" {...attributes} {...listeners}>
+        <span style={{ cursor: 'grab', color: '#9ca3af', fontSize: '1.2rem' }}>⠿</span>
+      </td>
+      <td className="table-body-cell">
+        <span className={`category-tag ${question.measurement_category}`}>
+          {CATEGORY_LABELS[question.measurement_category]}
+        </span>
+      </td>
+      <td className="table-body-cell">{question.text}</td>
+      <td className="table-body-cell">
+        <span className={`status-badge ${question.is_public ? 'public' : 'private'}`}>
+          {question.is_public ? '公開中' : '非公開'}
+        </span>
+      </td>
+      <td className="table-body-cell">
+        <div className="table-actions">
+          <button onClick={() => onEdit(question)} className="edit-button">編集</button>
+          <button onClick={() => onTogglePublish(question.id, question.is_public)} className="toggle-publish-button">
+            {question.is_public ? '非公開にする' : '公開にする'}
+          </button>
+          <button onClick={() => onDelete(question.id)} className="delete-button">削除</button>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+const QuestionManage: React.FC = () => {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [editingQuestion, setEditingQuestion] = useState<Question | null>(null);
+  const [formData, setFormData] = useState<QuestionCreate>({
+    measurement_category: "satisfaction",
+    text: "",
+    is_public: true,
+    sort_order: 0,
+  });
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5, // 誤作動防止
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const fetchQuestions = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getAdminQuestions();
+      setQuestions([...data].sort((a, b) => a.sort_order - b.sort_order));
+      setError(null);
+    } catch (err) {
+      console.error('Failed to fetch questions:', err);
+      setError('質問の取得に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchQuestions();
+  }, [fetchQuestions]);
+
+  const openModal = (question?: Question) => {
+    if (question) {
+      setEditingQuestion(question);
+      setFormData({
+        measurement_category: question.measurement_category,
+        text: question.text,
+        is_public: question.is_public,
+        sort_order: question.sort_order,
+      });
+    } else {
+      setEditingQuestion(null);
+      setFormData({
+        measurement_category: "satisfaction",
+        text: "",
+        is_public: true,
+        sort_order: questions.length,
+      });
+    }
+    dialogRef.current?.showModal();
+  };
+
+  const closeModal = () => {
+    dialogRef.current?.close();
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === dialogRef.current) closeModal();
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.text.trim()) return alert("質問内容を入力してください");
+
+    setIsSaving(true);
+    try {
+      if (editingQuestion) {
+        await updateQuestion(editingQuestion.id, formData);
+      } else {
+        await createQuestion(formData);
+      }
+      await fetchQuestions();
+      closeModal();
+    } catch (err) {
+      alert("保存に失敗しました");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("本当に削除しますか？")) return;
+    try {
+      await deleteQuestion(id);
+      await fetchQuestions();
+    } catch (err) {
+      alert("削除に失敗しました");
+    }
+  };
+
+  const handleTogglePublish = async (id: number, currentStatus: boolean) => {
+    try {
+      await patchPublishQuestion(id, !currentStatus);
+      setQuestions(prev => prev.map(q => q.id === id ? { ...q, is_public: !currentStatus } : q));
+    } catch (err) {
+      console.error('Failed to toggle publish:', err);
+      alert('公開状態の切り替えに失敗しました。');
+    }
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = questions.findIndex((q) => q.id === active.id);
+      const newIndex = questions.findIndex((q) => q.id === over.id);
+
+      const newQuestions = arrayMove(questions, oldIndex, newIndex);
+      const reorderedQuestions = newQuestions.map((q, idx) => ({ ...q, sort_order: idx }));
+
+      setQuestions(reorderedQuestions);
+
+      try {
+        await reorderQuestions({
+          orders: reorderedQuestions.map(q => ({ id: q.id, sort_order: q.sort_order }))
+        });
+      } catch (err) {
+        console.error('Failed to reorder:', err);
+        alert('並び替えの保存に失敗しました。');
+        fetchQuestions();
+      }
+    }
+  };
+
+  const questionIds = useMemo(() => questions.map(q => q.id), [questions]);
+
+  return (
+    <div className="card-base dashboard-container">
+      <div className="admin-header">
+        <h2>質問管理画面</h2>
+        <button className="add-button" onClick={() => openModal()}>
+          質問を追加
+        </button>
+      </div>
+
+      {error && <p className="alert-error">{error}</p>}
+
+      <dialog ref={dialogRef} className="modal-container" onClick={handleBackdropClick}>
+        <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+          <h3>{editingQuestion ? "質問の編集" : "質問の追加"}</h3>
+          <form onSubmit={handleSave}>
+            <div className="form-group">
+              <label>質問の内容</label>
+              <input
+                type="text"
+                required
+                value={formData.text}
+                onChange={(e) => setFormData({ ...formData, text: e.target.value })}
+                placeholder="例: 今日の体調はどうですか？"
+              />
+            </div>
+
+            <div className="form-group">
+              <label>カテゴリー</label>
+              <select
+                className="form-select"
+                value={formData.measurement_category}
+                onChange={(e) => setFormData({ ...formData, measurement_category: e.target.value })}
+              >
+                {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+                  <option key={key} value={key}>{label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label>公開設定</label>
+              <select
+                className="form-select"
+                value={formData.is_public ? "true" : "false"}
+                onChange={(e) => setFormData({ ...formData, is_public: e.target.value === "true" })}
+              >
+                <option value="true">公開</option>
+                <option value="false">非公開</option>
+              </select>
+            </div>
+
+            <div className="modal-actions">
+              <button type="button" onClick={closeModal} className="modal-cancel-button" disabled={isSaving}>
+                キャンセル
+              </button>
+              <button type="submit" className="modal-save-button" disabled={isSaving}>
+                {isSaving ? "保存中..." : "保存する"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </dialog>
+
+      {loading && questions.length === 0 ? (
+        <p>読み込み中...</p>
+      ) : questions.length === 0 ? (
+        <p className="text-muted">質問が登録されていません。</p>
+      ) : (
+        <div className="table-container">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+            modifiers={[restrictToVerticalAxis, restrictToWindowEdges, restrictToParentElement]}
+          >
+            <table className="history-table">
+              <thead>
+                <tr className="table-header-row">
+                  <th className="table-header-cell drag-handle" style={{ width: '40px' }}></th>
+                  <th className="table-header-cell">カテゴリ</th>
+                  <th className="table-header-cell">質問文</th>
+                  <th className="table-header-cell is_public">公開</th>
+                  <th className="table-header-cell actions">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <SortableContext items={questionIds} strategy={verticalListSortingStrategy}>
+                  {questions.map((question) => (
+                    <SortableRow
+                      key={question.id}
+                      question={question}
+                      onEdit={openModal}
+                      onTogglePublish={handleTogglePublish}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </SortableContext>
+              </tbody>
+            </table>
+          </DndContext>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuestionManage;

--- a/frontend/src/pages/QuestionManage.tsx
+++ b/frontend/src/pages/QuestionManage.tsx
@@ -83,6 +83,9 @@ const SortableRow: React.FC<SortableRowProps> = ({ question, onEdit, onTogglePub
         </span>
       </td>
       <td className="table-body-cell">
+        {question.sort_order}
+      </td>
+      <td className="table-body-cell">
         <div className="table-actions">
           <button onClick={() => onEdit(question)} className="edit-button">編集</button>
           <button onClick={() => onTogglePublish(question.id, question.is_public)} className="toggle-publish-button">
@@ -317,6 +320,7 @@ const QuestionManage: React.FC = () => {
                   <th className="table-header-cell">カテゴリ</th>
                   <th className="table-header-cell">質問文</th>
                   <th className="table-header-cell is_public">公開</th>
+                  <th className="table-header-cell sort_order">順</th>
                   <th className="table-header-cell actions">操作</th>
                 </tr>
               </thead>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -15,10 +15,26 @@ export interface User {
 
 export interface Question {
   id: number;
-  measurement_category: 'satisfaction' | 'relationship' | 'health';
+  measurement_category: string;
   text: string;
   is_public: boolean;
   sort_order: number;
+}
+
+export interface QuestionCreate {
+  measurement_category: string;
+  text: string;
+  is_public: boolean;
+  sort_order: number;
+}
+
+export interface QuestionSortOrder {
+  id: number;
+  sort_order: number;
+}
+
+export interface QuestionBulkReorderPayload {
+  orders: QuestionSortOrder[];
 }
 
 export interface Answer {
@@ -52,6 +68,36 @@ export const logout = async (): Promise<void> => {
 
 export const getQuestions = async (): Promise<Question[]> => {
   const response = await api.get<Question[]>('/questions');
+  return response.data;
+};
+
+export const getAdminQuestions = async (): Promise<Question[]> => {
+  const response = await api.get<Question[]>('/admin/questions');
+  return response.data;
+};
+
+export const createQuestion = async (payload: QuestionCreate): Promise<Question> => {
+  console.log(payload);
+  const response = await api.post<Question>('/admin/questions', payload);
+  return response.data;
+};
+
+export const updateQuestion = async (id: number, payload: QuestionCreate): Promise<Question> => {
+  const response = await api.put<Question>(`/admin/questions/${id}`, payload);
+  return response.data;
+};
+
+export const deleteQuestion = async (id: number): Promise<void> => {
+  await api.delete(`/admin/questions/${id}`);
+};
+
+export const patchPublishQuestion = async (id: number, is_public: boolean): Promise<Question> => {
+  const response = await api.patch<Question>(`/admin/questions/${id}/visibility`, { is_public });
+  return response.data;
+};
+
+export const reorderQuestions = async (payload: QuestionBulkReorderPayload): Promise<{ message: string; updated_ids: number[] }> => {
+  const response = await api.put<{ message: string; updated_ids: number[] }>('/admin/questions/reorder', payload);
   return response.data;
 };
 


### PR DESCRIPTION
## Issue

closes #10

## 完了条件の確認

- [x] 質問管理APIと正しく通信できること
- [x] 順序の入れ替えがAPIに反映されること

## 変更内容

- 質問の一覧表示（カテゴリ、質問文、公開状態、表示順）画面の実装
- 質問の「追加」「編集」「公開切替」「削除」が可能な操作UIの実装
- 表示順をドラッグ＆ドロップで変更可能なUIの実装

## その他

- [x] 動作確認済み
- [x] ドキュメントの更新が必要な場合は対応済み
