### PR TITLE
#45 axiosのバージョン指定を1.13.6に固定

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "axios": "^1.13.6",
+        "axios": "1.13.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "axios": "^1.13.6",
+    "axios": "1.13.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"


### PR DESCRIPTION
## Issue

closes #45

## 完了条件の確認

- [x] axiosのバージョンが1.13.6となっていること
  - 起動後に`docker compose exec frontend npm list axios`を実行し確認

## 変更内容

- package.jsonに記載されているaxiosのバージョンを1.13.6に固定(キャレットを削除)
- package-lock.jsonに記載されているaxiosのバージョンを1.13.6に固定(キャレットを削除)

## その他

- [x] 動作確認済み
- [x] ドキュメントの更新が必要な場合は対応済み
