### PR TITLE
#35 回答入力画面の修正

### DIFF
--- a/backend/app/routers/answers.py
+++ b/backend/app/routers/answers.py
@@ -1,6 +1,6 @@
+from calendar import monthrange
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from sqlalchemy.orm import Session
-from sqlalchemy.exc import IntegrityError
 from typing import List, Optional
 from datetime import date
 
@@ -11,6 +11,22 @@ from app.models.user import User
 from app.schemas.answer import AnswersBulkCreate, AnswerUpdate, AnswerResponse
 
 router = APIRouter(prefix="/api/answers", tags=["answers"])
+
+
+def _month_bounds(d: date) -> tuple[date, date]:
+    """同一カレンダー月の初日・末日（date）。"""
+    last = monthrange(d.year, d.month)[1]
+    return date(d.year, d.month, 1), date(d.year, d.month, last)
+
+
+def _question_answer_type_str(question: Question) -> str:
+    """DB/ORM により Enum インスタンスまたは str になる場合があるため統一する。"""
+    v = getattr(question, "answer_type", None)
+    if v is None:
+        return "rating"
+    if isinstance(v, str):
+        return v
+    return getattr(v, "value", str(v))
 
 
 @router.get("", response_model=List[AnswerResponse])
@@ -40,19 +56,55 @@ async def create_answers(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    # 複数質問に対する回答を一括登録。同一日・同一質問は上書き（UPSERT）。
+    """一括登録。同一ユーザー・同一質問・同一月内は別日の2回目を禁止。同一日は UPSERT。"""
     results = []
+    month_start, month_end = _month_bounds(payload.answer_date)
 
     for item in payload.answers:
-        # 質問の存在確認
-        question = db.query(Question).filter(Question.id == item.question_id).first()
+        question = (
+            db.query(Question)
+            .filter(Question.id == item.question_id, Question.deleted_at.is_(None))
+            .first()
+        )
         if not question:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"question_id={item.question_id} は存在しません",
             )
 
-        # 同一ユーザー・同一質問・同一日付の既存回答を検索（UPSERT）
+        # answer_type に応じた必須項目（Issue #35）
+        at = _question_answer_type_str(question)
+        if at == "rating":
+            if item.rating is None or not (1 <= item.rating <= 5):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="レーティング形式の設問には 1〜5 の評価が必須です",
+                )
+        elif at == "free":
+            if item.free_text is None or not str(item.free_text).strip():
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="自由記述形式の設問には本文が必須です",
+                )
+
+        # 同一月内・別日の回答があれば不可（同一日のみ UPSERT 可）
+        in_month = (
+            db.query(Answer)
+            .filter(
+                Answer.user_id == current_user.id,
+                Answer.question_id == item.question_id,
+                Answer.answer_date >= month_start,
+                Answer.answer_date <= month_end,
+            )
+            .all()
+        )
+        for row in in_month:
+            if row.answer_date != payload.answer_date:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="同一月内に既に回答が登録されています。履歴画面からご確認ください。",
+                )
+
         existing = (
             db.query(Answer)
             .filter(
@@ -64,21 +116,22 @@ async def create_answers(
         )
 
         if existing:
-            # 既存レコードを更新
-            if item.rating is not None:
+            if at == "rating":
                 existing.rating = item.rating
-            if item.free_text is not None:
-                existing.free_text = item.free_text
+                if item.free_text is not None:
+                    existing.free_text = item.free_text
+            else:
+                existing.free_text = item.free_text.strip() if item.free_text else None
+                existing.rating = None
             db.flush()
             results.append(existing)
         else:
-            # 新規登録
             new_answer = Answer(
                 user_id=current_user.id,
                 question_id=item.question_id,
                 answer_date=payload.answer_date,
-                rating=item.rating,
-                free_text=item.free_text,
+                rating=item.rating if at == "rating" else None,
+                free_text=(item.free_text.strip() if item.free_text else None) if at == "free" else item.free_text,
             )
             db.add(new_answer)
             db.flush()

--- a/backend/app/schemas/questions.py
+++ b/backend/app/schemas/questions.py
@@ -12,10 +12,6 @@ class AnswerType(str, Enum):
     RATING = "rating"
     FREE = "free"
 
-class AnswerType(str, Enum):
-    RATING = "rating"
-    FREE = "free"
-
 class QuestionItemCreate(BaseModel):
     category: Category
     answer_type: AnswerType = AnswerType.RATING

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -397,6 +397,26 @@ body {
   overflow: hidden;
 }
 
+.alert-info {
+  background-color: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+  padding: 16px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  font-size: 0.875rem;
+}
+
+.alert-info-text {
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+a.save-button.alert-info-link {
+  text-decoration: none;
+  display: inline-block;
+}
+
 .progress-bar {
   position: absolute;
   bottom: 0;

--- a/frontend/src/pages/AnswerInput.tsx
+++ b/frontend/src/pages/AnswerInput.tsx
@@ -1,21 +1,51 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { getQuestions, createAnswers, getAnswers, Question, AnswerCreate } from '../services/api';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import axios from 'axios';
+import {
+  getQuestions,
+  createAnswers,
+  getAnswers,
+  Question,
+  AnswerCreate,
+  QuestionAnswerType,
+} from '../services/api';
+
+/** ローカル日付 YYYY-MM-DD（回答日はシステム日付で固定。Issue #35） */
+function todayLocalYmd(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function monthRangeYmd(d: Date): { start: string; end: string } {
+  const y = d.getFullYear();
+  const m = d.getMonth();
+  const start = `${y}-${String(m + 1).padStart(2, '0')}-01`;
+  const lastDay = new Date(y, m + 1, 0).getDate();
+  const end = `${y}-${String(m + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+  return { start, end };
+}
 
 const AnswerInput: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dateParam = searchParams.get('date');
 
+  const fixedToday = useMemo(() => todayLocalYmd(), []);
+
   const [questions, setQuestions] = useState<Question[]>([]);
   const [answerDate, setAnswerDate] = useState<string>(
-    dateParam || new Date().toISOString().split('T')[0]
+    () => dateParam || fixedToday
   );
   const [answers, setAnswers] = useState<Record<string, AnswerCreate>>({});
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** 新規入力かつ当月に既存回答あり（Issue #35: 質問は出さずメッセージ＋履歴リンク） */
+  const [alreadyAnsweredThisMonth, setAlreadyAnsweredThisMonth] = useState(false);
 
   const showError = (message: string) => {
     setError(message);
@@ -29,49 +59,23 @@ const AnswerInput: React.FC = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const [questionsData, existingAnswersData] = await Promise.all([
-          getQuestions(),
-          dateParam ? getAnswers(dateParam, dateParam) : Promise.resolve([])
-        ]);
+        setAlreadyAnsweredThisMonth(false);
 
-        // 指定された日付の回答がない場合はエラーを表示
-        if (dateParam && existingAnswersData.length === 0) {
-          showError('指定された日付には回答履歴がありません。');
-          return;
-        }
+        if (!dateParam) {
+          const { start, end } = monthRangeYmd(new Date());
+          const [questionsData, monthAnswers] = await Promise.all([
+            getQuestions(),
+            getAnswers(start, end),
+          ]);
+          if (monthAnswers.length > 0) {
+            setAlreadyAnsweredThisMonth(true);
+            setQuestions([]);
+            setAnswers({});
+            return;
+          }
+          setAnswerDate(fixedToday);
 
-        if (dateParam) {
-          // 編集モード：既存の回答がある質問のみを表示
-          const displayQuestions = existingAnswersData.map(ans => {
-            const q = questionsData.find(pq => pq.id === ans.question_id);
-            if (q) return q;
-            return {
-              id: ans.question_id,
-              text: '（現在非公開、または取得できない質問内容です）',
-              category: 'work',
-              is_public: false,
-              sort_order: 999,
-              is_missing: true
-            } as any;
-          });
-
-          // 表示順序でソート
-          displayQuestions.sort((a: any, b: any) => a.sort_order - b.sort_order);
-          setQuestions(displayQuestions);
-
-          const initialAnswers: Record<string, AnswerCreate> = {};
-          existingAnswersData.forEach(ans => {
-            initialAnswers[ans.question_id] = {
-              question_id: ans.question_id,
-              rating: ans.rating,
-              free_text: ans.free_text || ''
-            };
-          });
-          setAnswers(initialAnswers);
-        } else {
-          // 新規作成モード：すべての公開中質問を表示
           setQuestions(questionsData.sort((a, b) => a.sort_order - b.sort_order));
-
           const initialAnswers: Record<string, AnswerCreate> = {};
           questionsData.forEach(q => {
             initialAnswers[q.id] = {
@@ -81,7 +85,50 @@ const AnswerInput: React.FC = () => {
             };
           });
           setAnswers(initialAnswers);
+          return;
         }
+
+        setAnswerDate(dateParam);
+        const [questionsData, existingAnswersData] = await Promise.all([
+          getQuestions(),
+          getAnswers(dateParam, dateParam),
+        ]);
+
+        // 指定された日付の回答がない場合はエラーを表示
+        if (existingAnswersData.length === 0) {
+          showError('指定された日付には回答履歴がありません。');
+          return;
+        }
+
+        // 編集モード：既存の回答がある質問のみを表示
+        const displayQuestions = existingAnswersData.map(ans => {
+          const q = questionsData.find(pq => pq.id === ans.question_id);
+          if (q) return q;
+          const inferredFree = ans.rating == null && !!(ans.free_text && String(ans.free_text).trim());
+          const answerType: QuestionAnswerType = inferredFree ? 'free' : 'rating';
+          return {
+            id: ans.question_id,
+            text: '（現在非公開、または取得できない質問内容です）',
+            category: 'work',
+            answer_type: answerType,
+            is_public: false,
+            sort_order: 999,
+            is_missing: true
+          } as any;
+        });
+
+        displayQuestions.sort((a: any, b: any) => a.sort_order - b.sort_order);
+        setQuestions(displayQuestions);
+
+        const initialAnswers: Record<string, AnswerCreate> = {};
+        existingAnswersData.forEach(ans => {
+          initialAnswers[ans.question_id] = {
+            question_id: ans.question_id,
+            rating: ans.rating,
+            free_text: ans.free_text || ''
+          };
+        });
+        setAnswers(initialAnswers);
       } catch (err) {
         console.error('Failed to fetch data:', err);
         showError('データの取得に失敗しました。');
@@ -95,18 +142,7 @@ const AnswerInput: React.FC = () => {
       setError(null);
       setAnswers({});
     };
-  }, [dateParam]);
-
-  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedDate = e.target.value;
-    setAnswerDate(selectedDate);
-    const today = new Date().toISOString().split('T')[0];
-    if (selectedDate > today) {
-      setError('未来の日付で回答を登録することはできません。');
-    } else {
-      setError(null);
-    }
-  };
+  }, [dateParam, fixedToday]);
 
   const handleRatingChange = (questionId: string, rating: number) => {
     setAnswers(prev => ({
@@ -125,18 +161,28 @@ const AnswerInput: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // バリデーション
-    const today = new Date().toISOString().split('T')[0];
+    const today = todayLocalYmd();
     if (answerDate > today) {
       showError('未来の日付で回答を登録することはできません。');
       return;
     }
 
-    // 必須チェック（5段階評価）
-    const missingRating = questions.some(q => answers[q.id]?.rating === null);
-    if (missingRating) {
-      showError('すべての質問に対して5段階評価を入力してください。');
-      return;
+    const atype = (q: Question) => q.answer_type ?? 'rating';
+    for (const q of questions) {
+      if ((q as any).is_missing) continue;
+      const a = answers[q.id];
+      if (!a) continue;
+      if (atype(q) === 'rating') {
+        if (a.rating === null || a.rating === undefined) {
+          showError('レーティング形式の設問はすべて 1〜5 を選択してください。');
+          return;
+        }
+      } else {
+        if (!a.free_text?.trim()) {
+          showError('自由記述形式の設問は本文の入力が必須です。');
+          return;
+        }
+      }
     }
 
     try {
@@ -147,15 +193,18 @@ const AnswerInput: React.FC = () => {
         answers: Object.values(answers)
       });
       setIsSubmitted(true);
-      // alert('回答を保存しました。');
-      // navigate('/history');
-      // 3秒後に一覧画面へ自動遷移
       setTimeout(() => {
-        navigate('/history'); // 一覧のパス
+        navigate('/history');
       }, 3000);
     } catch (err) {
       console.error('Failed to save answers:', err);
-      showError('回答の保存に失敗しました。');
+      let msg = '回答の保存に失敗しました。';
+      if (axios.isAxiosError(err)) {
+        const d = err.response?.data;
+        if (typeof d?.detail === 'string') msg = d.detail;
+        else if (Array.isArray(d?.detail)) msg = d.detail.map((x: { msg?: string }) => x.msg || '').join(' ') || msg;
+      }
+      showError(msg);
       setIsSubmitted(false);
     } finally {
       setSubmitting(false);
@@ -163,6 +212,22 @@ const AnswerInput: React.FC = () => {
   };
 
   if (loading) return <div className="dashboard-container">読み込み中...</div>;
+
+  if (!dateParam && alreadyAnsweredThisMonth) {
+    return (
+      <div className="card-base dashboard-container">
+        <h2>回答入力</h2>
+        <div className="alert-info">
+          <p className="alert-info-text">
+            当月は既に回答を登録しています。履歴画面から内容をご確認ください。
+          </p>
+          <Link to="/history" className="save-button alert-info-link">
+            回答履歴を見る
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="card-base dashboard-container">
@@ -184,16 +249,24 @@ const AnswerInput: React.FC = () => {
       <form onSubmit={handleSubmit} noValidate>
         <div className="form-item form-item-date">
           <label htmlFor="answer-date">回答日</label>
-          <input
-            id="answer-date"
-            type="date"
-            value={answerDate}
-            onChange={handleDateChange}
-            max={new Date().toISOString().split('T')[0]}
-            required
-            disabled={!!dateParam} // 編集時は日付固定
-            className="form-date-input"
-          />
+          {dateParam ? (
+            <input
+              id="answer-date"
+              type="date"
+              value={answerDate}
+              readOnly
+              className="form-date-input"
+            />
+          ) : (
+            <input
+              id="answer-date"
+              type="text"
+              value={answerDate}
+              readOnly
+              className="form-date-input"
+              aria-readonly="true"
+            />
+          )}
         </div>
 
         <div className="questions-container">
@@ -208,33 +281,36 @@ const AnswerInput: React.FC = () => {
                 )}
               </p>
 
-              <div className="rating">
-                {[1, 2, 3, 4, 5].map((num) => (
-                  <label key={num} className="rating-label">
-                    <input
-                      type="radio"
-                      name={`question-${q.id}`}
-                      value={num}
-                      checked={answers[q.id]?.rating === num}
-                      onChange={() => handleRatingChange(q.id, num)}
-                      className="rating-input"
-                      disabled={submitting || (q as any).is_missing}
-                    />
-                    {num}
-                  </label>
-                ))}
-              </div>
-
-              <div className="free-text-container">
-                <label className="free-text-label">自由記述（任意）</label>
-                <textarea
-                  className="free-text-area"
-                  value={answers[q.id]?.free_text || ''}
-                  onChange={(e) => handleTextChange(q.id, e.target.value)}
-                  placeholder={(q as any).is_missing ? "編集できません" : "具体的に気になることがあれば記入してください"}
-                  disabled={submitting || (q as any).is_missing}
-                />
-              </div>
+              {(q.answer_type ?? 'rating') === 'rating' ? (
+                <div className="rating">
+                  {[1, 2, 3, 4, 5].map((num) => (
+                    <label key={num} className="rating-label">
+                      <input
+                        type="radio"
+                        name={`question-${q.id}`}
+                        value={num}
+                        checked={answers[q.id]?.rating === num}
+                        onChange={() => handleRatingChange(q.id, num)}
+                        className="rating-input"
+                        disabled={submitting || (q as any).is_missing}
+                      />
+                      {num}
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <div className="free-text-container">
+                  <label className="free-text-label">自由記述（必須）</label>
+                  <textarea
+                    className="free-text-area"
+                    value={answers[q.id]?.free_text || ''}
+                    onChange={(e) => handleTextChange(q.id, e.target.value)}
+                    placeholder={(q as any).is_missing ? '編集できません' : '回答を入力してください'}
+                    disabled={submitting || (q as any).is_missing}
+                    required
+                  />
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -21,9 +21,12 @@ export interface User {
 /** バックエンドの Category enum（work / relationship / health）に合わせる */
 export type QuestionCategory = 'work' | 'relationship' | 'health';
 
+export type QuestionAnswerType = 'rating' | 'free';
+
 export interface Question {
   id: string;
   category: QuestionCategory;
+  answer_type: QuestionAnswerType;
   text: string;
   is_public: boolean;
   sort_order: number;


### PR DESCRIPTION
## Issue

closes #35 

## 完了条件の確認

- [x] ユーザーが日付を選択することなく回答を保存できること
- [x] 同一月内に2回以上の回答を送信しようとした場合、サーバ側でエラーが返されること
- [x] answer_typeに応じて rating/free の入力欄を表示すること

## 変更内容

- **Frontend**: 
  - 回答日選択フィールドにて変更を不可とする。回答日で固定する。
  - 当月回答済みの場合は質問を表示せず、回答済であることを示すメッセージおよび履歴画面へのリンクを表示する。
  - answer_typeに応じて rating/free の入力欄を表示する。
- **Backend**: 
  - 同一ユーザー、同一質問、同一月内の多重投稿を制限するバリデーションの実装。

## その他

- [x] 動作確認済み
- [x] ドキュメントの更新が必要な場合は対応済み
